### PR TITLE
Fix: added missing <cmath> header to fix compilation

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -2,6 +2,7 @@
 #include "imagecontainer.h"
 #include "vqtools.h"
 #include <assert.h>
+#include <cmath>
 
 static inline bool powerOfTwo(int x) {
 	return ((x != 0) && !(x & (x - 1)));

--- a/vqtools.h
+++ b/vqtools.h
@@ -7,6 +7,7 @@
 #include <QElapsedTimer>
 #include <QColor>
 #include <QFile>
+#include <cmath>
 
 // N-dimensional vectors, for input to a VectorQuantizer.
 template <uint N>


### PR DESCRIPTION
Fixes the following compilation errors:

common.cpp: In function ‘quint16 toSpherical(QRgb)’:
common.cpp:70:42: error: ‘acos’ was not declared in this scope
  float polar = acos(cartesian[2] / radius);
                                          ^
common.cpp:71:50: error: ‘atan2’ was not declared in this scope
  float azimuth = atan2(cartesian[1], cartesian[0]);
                                                  ^
common.cpp:60:18: error: ‘M_PI’ was not declared in this scope
 #define HALFPI  (M_PI / 2.0)
                  ^
common.cpp:76:10: note: in expansion of macro ‘HALFPI’
  polar = HALFPI - polar;    // -HALFPI ... HALFPI
          ^~~~~~
common.cpp: In function ‘QRgb toCartesian(quint16)’:
common.cpp:60:18: error: ‘M_PI’ was not declared in this scope
 #define HALFPI  (M_PI / 2.0)
                  ^
common.cpp:90:42: note: in expansion of macro ‘HALFPI’
  float S = (1.0 - ((SR >> 8) / 255.0)) * HALFPI;
                                          ^~~~~~
common.cpp:94:11: error: ‘sin’ was not declared in this scope
     (sin(S) * cos(R) + 1.0f) * 0.5f,
           ^
common.cpp:94:20: error: ‘cos’ was not declared in this scope
     (sin(S) * cos(R) + 1.0f) * 0.5f,
                    ^
In file included from common.cpp:3:0:
vqtools.h: In instantiation of ‘float Vec<N>::length() const [with unsigned int N = 3u]’:
common.cpp:69:34:   required from here
vqtools.h:181:13: error: ‘sqrt’ was not declared in this scope
  return sqrt(lengthSquared());